### PR TITLE
docs: add copy-pasteable command for setting up local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ pnpm install
 
 2. Copy `.env.example` to `.env.local` and update the variables.
 
+```sh
+cp .env.example .env.local
+```
+
 3. Start the development server:
 
 ```sh


### PR DESCRIPTION
This pull request adds a simple `cp` command which partially implements the second step of the **Running Locally** section.