### PR TITLE
fix: add space between sentences

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -187,7 +187,7 @@ export default async function IndexPage() {
             >
               GitHub
             </Link>
-            .
+            .{" "}
             <Link href="/docs" className="underline underline-offset-4">
               I&apos;m also documenting everything here
             </Link>


### PR DESCRIPTION
This pull request restores an “eaten-by-JSX” space between sentences of the **Proudly Open Source** section.