### PR TITLE
fix: Markdown typos

### DIFF
--- a/content/blog/deploying-next-apps.mdx
+++ b/content/blog/deploying-next-apps.mdx
@@ -210,7 +210,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 

--- a/content/blog/dynamic-routing-static-regeneration.mdx
+++ b/content/blog/dynamic-routing-static-regeneration.mdx
@@ -210,7 +210,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 

--- a/content/blog/preview-mode-headless-cms.mdx
+++ b/content/blog/preview-mode-headless-cms.mdx
@@ -210,7 +210,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 

--- a/content/blog/server-client-components.mdx
+++ b/content/blog/server-client-components.mdx
@@ -210,7 +210,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 

--- a/content/docs/documentation/components.mdx
+++ b/content/docs/documentation/components.mdx
@@ -131,7 +131,7 @@ const components = {
 }
 ```
 
-This will overwrite the `<hr />` tag or `---` in Mardown with the HTML output above.
+This will overwrite the `<hr />` tag or `---` in Markdown with the HTML output above.
 
 ---
 

--- a/content/docs/documentation/index.mdx
+++ b/content/docs/documentation/index.mdx
@@ -37,7 +37,7 @@ Learn how to use MDX with Contentlayer.
 
 ### Components
 
-Using React components in Mardown.
+Using React components in Markdown.
 
 </Card>
 

--- a/content/docs/documentation/style-guide.mdx
+++ b/content/docs/documentation/style-guide.mdx
@@ -207,7 +207,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 

--- a/content/guides/build-blog-using-contentlayer-mdx.mdx
+++ b/content/guides/build-blog-using-contentlayer-mdx.mdx
@@ -213,7 +213,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 

--- a/content/guides/using-next-auth-next-13.mdx
+++ b/content/guides/using-next-auth-next-13.mdx
@@ -213,7 +213,7 @@ What I've written here is probably long enough, but adding this final sentence c
 
 ## GitHub Flavored Markdown
 
-I've also added support for GitHub Flavored Mardown using `remark-gfm`.
+I've also added support for GitHub Flavored Markdown using `remark-gfm`.
 
 With `remark-gfm`, we get a few extra features in our markdown. Example: autolink literals.
 


### PR DESCRIPTION
Update 'Mardown' typo sitewide to 'Markdown'