### PR TITLE
Wrap heading text in anchor tag

### DIFF
--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -170,6 +170,7 @@ export default makeSource({
       [
         rehypeAutolinkHeadings,
         {
+          behavior: "wrap",
           properties: {
             className: ["subheading-anchor"],
             ariaLabel: "Link to section",


### PR DESCRIPTION
Headings were not linked previously because the anchor tag didn't wrap the header text.

With this simple change, the headers are clickable.