### PR TITLE
fix: ContentLayer url

### DIFF
--- a/content/docs/documentation/index.mdx
+++ b/content/docs/documentation/index.mdx
@@ -25,7 +25,7 @@ Click on a section below to learn how the documentation site built.
 
 <div className="grid gap-4 mt-6">
 
-<Card href="/docs/documentation/contentlayer">
+<Card href="https://contentlayer.dev">
 
 ### Contentlayer
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: Welcome to the Taxonomy documentation.
 
 This is the documentation for the Taxonomy site.
 
-I'm going to use this to document all the features of Taxonomy and how they are built. The documentation site is built using [ContentLayer](/docs/documentation/contentlayer) and MDX.
+I'm going to use this to document all the features of Taxonomy and how they are built. The documentation site is built using [ContentLayer](https://www.contentlayer.dev/) and MDX.
 
 <Callout>
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: Welcome to the Taxonomy documentation.
 
 This is the documentation for the Taxonomy site.
 
-I'm going to use this to document all the features of Taxonomy and how they are built. The documentation site is built using [ContentLayer](https://www.contentlayer.dev/) and MDX.
+I'm going to use this to document all the features of Taxonomy and how they are built. The documentation site is built using [ContentLayer](https://contentlayer.dev) and MDX.
 
 <Callout>
 


### PR DESCRIPTION
The url of `ConentLayer` is `/docs/documentation/contentlayer`, while this page is not existed. This PR changes url to `https://contentlayer.dev`.