### PR TITLE
Spelling mistake

### DIFF
--- a/content/docs/documentation/components.mdx
+++ b/content/docs/documentation/components.mdx
@@ -131,7 +131,7 @@ const components = {
 }
 ```
 
-This will overwrite the `<hr />` tag or `---` in Mardown with the HTML output above.
+This will overwrite the `<hr />` tag or `---` in Markdown with the HTML output above.
 
 ---
 


### PR DESCRIPTION
If it is referring to the Markdown language then it needs the letter k.