### PR TITLE
fix(editor): duplicate editor in DOM

### DIFF
--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -73,13 +73,11 @@ export function Editor({ post }: EditorProps) {
   }, [])
 
   React.useEffect(() => {
-    if (isMounted) {
-      initializeEditor()
+    if (isMounted) initializeEditor()
 
-      return () => {
-        ref.current?.destroy()
-        ref.current = undefined
-      }
+    return () => {
+      ref.current?.destroy()
+      ref.current = undefined
     }
   }, [isMounted, initializeEditor])
 


### PR DESCRIPTION
## Problem
use effect hook causes duplication of editor in the dom during development.

## Solution
extract the cleanup method from the **if** `isMounted` condition. nothing to worry about since the clean up does a safe destroy node using the `.?` & assign ref to undefined