### PR TITLE
Solved foreign key constraints are not allowed in Prisma Issue - #146

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,7 @@ generator client {
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
+  relationMode = "prisma"
 }
 
 model Account {


### PR DESCRIPTION
## Solved issue - #146 

For solving the issue we need to specify the relationmodel to prisma inside the code . 
Here's the docs I follow for this particular pr - https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode#how-to-set-the-relation-mode-in-your-prisma-schema


Hope it solves the issue. let me know if any corrections is being needed.