### PR TITLE
SidebarNavItem type should use NavItem[] not NavLink[]

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,7 +23,7 @@ export type SidebarNavItem = {
     }
   | {
       href?: string
-      items: NavLink[]
+      items: NavItem[]
     }
 )
 


### PR DESCRIPTION
This fixes the SidebarNavItem type which was using a type definition that didn't exist. Likely a typo that is fixed in this pull request.

Fixes this issue: #134 