### PR TITLE
fix: documentation Navbar issue #151

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -7,6 +7,7 @@ import { useSelectedLayoutSegment } from "next/navigation"
 import { MainNavItem } from "types"
 import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
+import { useShowMobileMenu } from "@/hooks/use-show-mobile-menu"
 import { Icons } from "@/components/icons"
 import { MobileNav } from "@/components/mobile-nav"
 
@@ -17,7 +18,7 @@ interface MainNavProps {
 
 export function MainNav({ items, children }: MainNavProps) {
   const segment = useSelectedLayoutSegment()
-  const [showMobileMenu, setShowMobileMenu] = React.useState<boolean>(false)
+  const [showMobileMenu, setShowMobileMenu] = useShowMobileMenu()
 
   return (
     <div className="flex gap-6 md:gap-10">

--- a/hooks/use-show-mobile-menu.ts
+++ b/hooks/use-show-mobile-menu.ts
@@ -1,0 +1,16 @@
+import * as React from "react"
+import { usePathname } from "next/navigation"
+
+export function useShowMobileMenu(): [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>
+] {
+  const [showMobileMenu, setShowMobileMenu] = React.useState<boolean>(false)
+  const pathname = usePathname()
+
+  React.useEffect(() => {
+    setShowMobileMenu(false)
+  }, [pathname])
+
+  return [showMobileMenu, setShowMobileMenu]
+}


### PR DESCRIPTION
# Issue #151 

Fixed the issue of nav menu doesn't closes when we clock the nav menu in the documentation on mobile devices. After this change, nav menu will automatically closes when the route changes.

## changes:
1. Create new hook to handle mobile nav menu.
2. Changed main nav Component accordingly