### PR TITLE
fix: prevent login btn from shifting on resize

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
         href="/"
         className={cn(
           buttonVariants({ variant: "ghost" }),
-          "absolute left-4 top-4 md:left-8 md:top-8"
+          "absolute left-8 top-8"
         )}
       >
         <>


### PR DESCRIPTION
Minor tweak to prevent login button from shifting during window resize.